### PR TITLE
insert order and line items in one atomic statement

### DIFF
--- a/wasm-components/rust/orders-service/src/lib.rs
+++ b/wasm-components/rust/orders-service/src/lib.rs
@@ -138,7 +138,8 @@ impl Guest for Component {
         FROM
             orders.t_order_line_items as line_items
             JOIN orders.t_orders_order_line_items_list as order_lines ON "order_lines".order_line_items_list_id = "line_items".id
-            JOIN orders.t_orders as "order" ON "order".id = "order_lines".order_id;
+            JOIN orders.t_orders as "order" ON "order".id = "order_lines".order_id
+        LIMIT 10;
         "#};
 
         let rows =


### PR DESCRIPTION
This allows us to load test order insertion. Previously this would break (as would any concurrent use) because we were inserting orders, line-items and join records in multiple calls to the database, wrapped in a transaction that would overlap with transactions from other instances. I suspect that the postgres provider we are using doesn't group multiple calls from the same wasm component onto a single db connection from the pool.
Anyway, now we only execute one SQL statement, using sequential CTEs, so that the writes (to all 3 tables) are atomic without a transaction.
A simple test on my machine now works:
```bash
> oha -c 20 -n 10000  'http://localhost:8080/orders' -m POST -d '[{"sku": "ENG-V8-500", "price": 1000, "quantity": 1}]'
Summary:
  Success rate: 100.00%
  Total:        5.4229 secs
  Slowest:      0.0619 secs
  Fastest:      0.0060 secs
  Average:      0.0108 secs
  Requests/sec: 1844.0272

  Total data:   117.19 KiB
  Size/request: 12 B
  Size/sec:     21.61 KiB

Response time histogram:
  0.006 [1]    |
  0.012 [7589] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.017 [2195] |■■■■■■■■■
  0.023 [114]  |
  0.028 [58]   |
  0.034 [16]   |
  0.040 [12]   |
  0.045 [3]    |
  0.051 [7]    |
  0.056 [1]    |
  0.062 [4]    |

Response time distribution:
  10.00% in 0.0086 secs
  25.00% in 0.0094 secs
  50.00% in 0.0103 secs
  75.00% in 0.0116 secs
  90.00% in 0.0132 secs
  95.00% in 0.0144 secs
  99.00% in 0.0228 secs
  99.90% in 0.0471 secs
  99.99% in 0.0594 secs


Details (average, fastest, slowest):
  DNS+dialup:   0.0024 secs, 0.0019 secs, 0.0029 secs
  DNS-lookup:   0.0002 secs, 0.0000 secs, 0.0005 secs

Status code distribution:
  [201] 10000 responses
```